### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,16 @@ jdk:
 script:
   - ./gradlew clean build
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.konan/cache/
+    - $HOME/.konan/dependencies/
+
 deploy:
   provider: script
   script: ./gradlew bintrayUpload

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+os:
+  - linux
+  - osx
+
+language: java
+
+jdk:
+  - openjdk8
+
+script:
+  - ./gradlew clean build
+
+deploy:
+  provider: script
+  script: ./gradlew bintrayUpload
+  skip_cleanup: true
+  dry-run: false
+  on:
+    branch: master

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -5,5 +5,3 @@ components.main {
 
     outputKinds = [KLIBRARY]
 }
-
-bintrayUpload.dependsOn publishToMavenLocal

--- a/publish.gradle
+++ b/publish.gradle
@@ -42,3 +42,13 @@ bintray {
         }
     }
 }
+
+bintrayUpload.dependsOn publishToMavenLocal
+
+bintrayUpload.doFirst {
+    publishing.publications.each {
+        if (it instanceof MavenPublication) {
+            println("Upload to bintray: publication \"${it.getArtifactId()}\", artifacts ${it.getArtifacts()}")
+        }
+    }
+}


### PR DESCRIPTION
Use Travis CI with images for linux and macOS. Currently, it's used for:
- Test execution
- On master: Deploy artifacts to bintray